### PR TITLE
call python via /usr/bin/env python to make script more portable

### DIFF
--- a/scripts/uncompyle2
+++ b/scripts/uncompyle2
@@ -1,4 +1,4 @@
-#! python
+#!/usr/bin/env python
 # Mode: -*- python -*-
 #
 # Copyright (c) 2000-2002 by hartmut Goebel <h.goebel@crazy-compilers.com>


### PR DESCRIPTION
The shebang line of the uncompyle2 script is not using /usr/bin/env python causing it to fail to run when invoked as a standalone script

``` Shell
uncompyle2# ./scripts/uncompyle2 -h
bash: ./scripts/uncompyle2: python: bad interpreter: No such file or directory
```

Changing the shebang line to #!/usr/bin/env python fixes the problem and is best practice (or so I'm told)

``` Shell
uncompyle2# ./scripts/uncompyle2 -h

Usage: uncompyle2 [OPTIONS]... [ FILE | DIR]...
...snip...
```
